### PR TITLE
feat : added endorse UI with staging for API call

### DIFF
--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -102,6 +102,14 @@ define('forum/topic/postTools', [
 		const postContainer = components.get('topic');
 
 		handleSelectionTooltip();
+		
+		postContainer.on('click', '[component="post/unendorse"]', function () {
+			return endorsePost($(this), getData($(this), 'data-pid'));
+		});
+
+		postContainer.on('click', '[component="post/endorse"]', function () {
+			return unEndorsePost($(this), getData($(this), 'data-pid'));
+		});
 
 		postContainer.on('click', '[component="post/quote"]', function () {
 			onQuoteClicked($(this), tid);
@@ -381,6 +389,42 @@ define('forum/topic/postTools', [
 			}
 			const type = method === 'put' ? 'bookmark' : 'unbookmark';
 			hooks.fire(`action:post.${type}`, { pid: pid });
+		});
+		return false;
+	}
+
+	function endorsePost(button, pid) {
+		const isEndorsed = button.attr('posts-endorsed') === 'true';
+		
+		if (isEndorsed) {
+			// alreayd endorsed, return
+			return false;
+		}
+		
+		// call API with PUT method, TODO : create API route for endorse
+		api.put(`/posts/${encodeURIComponent(pid)}/endorse`, undefined, function (err) {
+			if (err) {
+				return alerts.error(err);
+			}
+			// success : hooks.fire()?
+		});
+		return false;
+	}
+
+	function unEndorsePost(button, pid) {
+		const isEndorsed = button.attr('posts-endorsed') === 'true';
+		
+		if (!isEndorsed) {
+			// alreayd un-endorsed, return
+			return false;
+		}
+		
+		// call API with DEL method, TODO : create API route for unendorse
+		api.del(`/posts/${encodeURIComponent(pid)}/unendorse`, undefined, function (err) {
+			if (err) {
+				return alerts.error(err);
+			}
+			// success : hooks.fire()?
 		});
 		return false;
 	}

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
@@ -76,6 +76,7 @@
 			</div>
 			<div class="d-flex align-items-center gap-1 justify-content-end">
 				<span class="bookmarked opacity-0 text-primary"><i class="fa fa-bookmark-o"></i></span>
+				<span class="endorsed post-indicator {{{ if !posts.endorsed }}}hidden{{{ end }}}" title="The instructor / admin has endorsed this post!"><i class="fa fa-check-circle"></i></span>
 				<a href="{config.relative_path}/post/{encodeURIComponent(./pid)}" class="post-index text-muted d-none d-md-inline">#{increment(./index, "1")}</a>
 			</div>
 		</div>
@@ -109,6 +110,9 @@
 				{{{ end }}}
 				<div component="post/actions" class="d-flex flex-grow-1 align-items-center justify-content-end gap-1 post-tools">
 					<!-- IMPORT partials/topic/reactions.tpl -->
+					<!-- TODO : replace 'post-endorsed' attr variable after post field created -->
+					<a component="post/unendorse" href="#" class="btn btn-ghost btn-sm {{{ if !privileges.isAdminOrMod }}}hidden{{{ end }}}" title="Un-endorse this post" posts-endorsed="false"><i class="fa fa-fw fa-star-o text-primary"></i></a>
+					<a component="post/endorse" href="#" class="btn btn-ghost btn-sm {{{ if !privileges.isAdminOrMod }}}hidden{{{ end }}}" title="Endorse this post" posts-endorsed="true"><i class="fa fa-fw fa-star text-primary"></i></a>
 					<a component="post/reply" href="#" class="btn btn-ghost btn-sm {{{ if !privileges.topics:reply }}}hidden{{{ end }}}" title="[[topic:reply]]"><i class="fa fa-fw fa-reply text-primary"></i></a>
 					<a component="post/quote" href="#" class="btn btn-ghost btn-sm {{{ if !privileges.topics:reply }}}hidden{{{ end }}}" title="[[topic:quote]]"><i class="fa fa-fw fa-quote-right text-primary"></i></a>
 


### PR DESCRIPTION
## Disclaimer
I found the bookmarking functionality (already in NodeBB) to have a very similar logic to an endorsement feature would. Codebase analysis (process flow) and feature implementation was taken from the bookmarking feature. Recommend referencing / tracing through bookmarking to see how the process is done :)) 

## 1. Feature / Enhancement

Resolves #18 

1. Added endorsement buttons (endorse / un-endorse) when viewing specific topics
<img width="1904" height="990" alt="EndorseButton Screenshot" src="https://github.com/user-attachments/assets/64cd97a1-c266-44c9-8def-fe58f0f5d154" />
<img width="1903" height="990" alt="unendorseButton Screenshot" src="https://github.com/user-attachments/assets/72a67660-32e3-48a5-aeb0-eaced81b1e6c" />

2. Added 'Endorsed' checkmark
<img width="1906" height="992" alt="EndorseMark Screenshot" src="https://github.com/user-attachments/assets/7b873bad-61d7-4b69-8ed8-9ac8378e9bae" />

Currently, the visibility condition of the mark is not functional as it assume existence of 'endorsed' attribute (`posts.endorsed`) within the post. Post attributes seem to be retrieved during loading of the topic and its related posts. 

Referenced code : 
`<span class="endorsed post-indicate {{{ if !posts.endorsed }}}hidden{{{ end }}}" ... `
This is expected to work when the backend features are functional. 

3. Endorsement buttons limited visibility
<img width="1905" height="993" alt="non-admin hidden screenshot" src="https://github.com/user-attachments/assets/776fa6ad-10dc-4b79-9715-8c77d68e7005" />

This is a screenshot of individual topics from a test account that does not have admin privileges (normal user). The features are not shown and is hidden if the user is not an admin or a moderator.

4. EventListners and API call staging
`postTools.js` (client-side code) listens to button click events : made changes within `postTools.js` to call `endorsePost()` or `unEndorsePost()` depending on clicked component.

Within each called functions, `api.get(...)` is called for endorsements or `api.del(...)` for un-endorsements. Currently, the `isEndorsed` variable is hard-coded as the attribute in HTML component for the buttons depend on `posts.endorsed` existence. (the hard-coded `post-endorsed` attribute in the button can be changed for testing)

## 2. Testing
<img width="585" height="101" alt="Screenshot 2025-09-16 at 9 37 07 PM" src="https://github.com/user-attachments/assets/50074325-2fbb-497a-8b6f-c4bf3244ae1c" />

Testing done including front-end UI changes in `post.tpl` and API call function in `postTools.js` successful with no critical errors.

## 3. To-Do

- [ ] create API route to receive calls for endorsing / unendorsing
- [ ] analyze `hooks()` to determine endorse/unendorse success action
- [ ] create 'endorsed' DB field for posts


