### PR TITLE
Acee3/update schema for endorsements

### DIFF
--- a/public/openapi/components/schemas/PostObject.yaml
+++ b/public/openapi/components/schemas/PostObject.yaml
@@ -184,6 +184,11 @@ PostDataObject:
           type: number
         bookmarks:
           type: number
+        endorsements:
+          type: number
+        endorsed:
+          type: boolean
+          description: Whether the post has been endorsed (endorsements > 0)
         deleterUid:
           type: number
         edited:

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -7,7 +7,7 @@ const utils = require('../utils');
 const intFields = [
 	'uid', 'pid', 'tid', 'deleted', 'timestamp',
 	'upvotes', 'downvotes', 'deleterUid', 'edited',
-	'replies', 'bookmarks', 'announces', 'endoresements',
+	'replies', 'bookmarks', 'announces', 'endorsements',
 ];
 
 module.exports = function (Posts) {

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -7,7 +7,7 @@ const utils = require('../utils');
 const intFields = [
 	'uid', 'pid', 'tid', 'deleted', 'timestamp',
 	'upvotes', 'downvotes', 'deleterUid', 'edited',
-	'replies', 'bookmarks', 'announces', 'endorsements',
+	'replies', 'bookmarks', 'announces', 'endorsements', 'endorsed',
 ];
 
 module.exports = function (Posts) {
@@ -60,6 +60,9 @@ function modifyPost(post, fields) {
 		db.parseIntFields(post, intFields, fields);
 		if (post.hasOwnProperty('upvotes') && post.hasOwnProperty('downvotes')) {
 			post.votes = post.upvotes - post.downvotes;
+		}
+		if (post.hasOwnProperty('endorsements')) {
+			post.endorsed = post.endorsements > 0;
 		}
 		if (post.hasOwnProperty('timestamp')) {
 			post.timestampISO = utils.toISOString(post.timestamp);

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -7,7 +7,7 @@ const utils = require('../utils');
 const intFields = [
 	'uid', 'pid', 'tid', 'deleted', 'timestamp',
 	'upvotes', 'downvotes', 'deleterUid', 'edited',
-	'replies', 'bookmarks', 'announces',
+	'replies', 'bookmarks', 'announces', 'endoresements',
 ];
 
 module.exports = function (Posts) {

--- a/src/posts/endorsements.js
+++ b/src/posts/endorsements.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const db = require('../database');
+const plugins = require('../plugins');
+
+module.exports = function (Posts) {
+	Posts.endorse = async function (pid, uid) {
+		return await toggleEndorsement('endorse', pid, uid);
+	};
+
+	Posts.unendorse = async function (pid, uid) {
+		return await toggleEndorsement('unendorse', pid, uid);
+	};
+
+	async function toggleEndorsement(type, pid, uid) {
+		if (parseInt(uid, 10) <= 0) {
+			throw new Error('[[error:not-logged-in]]');
+		}
+
+		const isEndorsing = type === 'endorse';
+
+		const [postData, hasEndorsed] = await Promise.all([
+			Posts.getPostFields(pid, ['pid', 'uid']),
+			Posts.hasEndorsed(pid, uid),
+		]);
+
+		if (isEndorsing && hasEndorsed) {
+			throw new Error('[[error:already-endorsed]]');
+		}
+
+		if (!isEndorsing && !hasEndorsed) {
+			throw new Error('[[error:already-unendorsed]]');
+		}
+
+		if (isEndorsing) {
+			await db.sortedSetAdd(`uid:${uid}:endorsements`, Date.now(), pid);
+		} else {
+			await db.sortedSetRemove(`uid:${uid}:endorsements`, pid);
+		}
+		await db[isEndorsing ? 'setAdd' : 'setRemove'](`pid:${pid}:users_endorsed`, uid);
+		postData.endorsements = await db.setCount(`pid:${pid}:users_endorsed`);
+		await Posts.setPostField(pid, 'endorsements', postData.endorsements);
+
+		plugins.hooks.fire(`action:post.${type}`, {
+			pid: pid,
+			uid: uid,
+			owner: postData.uid,
+			current: hasEndorsed ? 'endorsed' : 'unendorsed',
+		});
+
+		return {
+			post: postData,
+			isEndorsed: isEndorsing,
+		};
+	}
+
+	Posts.hasEndorsed = async function (pid, uid) {
+		if (parseInt(uid, 10) <= 0) {
+			return Array.isArray(pid) ? pid.map(() => false) : false;
+		}
+
+		if (Array.isArray(pid)) {
+			const sets = pid.map(pid => `pid:${pid}:users_endorsed`);
+			return await db.isMemberOfSets(sets, uid);
+		}
+		return await db.isSetMember(`pid:${pid}:users_endorsed`, uid);
+	};
+};

--- a/src/posts/endorsements.js
+++ b/src/posts/endorsements.js
@@ -65,4 +65,12 @@ module.exports = function (Posts) {
 		}
 		return await db.isSetMember(`pid:${pid}:users_endorsed`, uid);
 	};
+
+	Posts.getEndorsers = async function (pid) {
+		return await db.getSetMembers(`pid:${pid}:users_endorsed`);
+	};
+
+	Posts.getEndorsersCount = async function (pid) {
+		return await db.setCount(`pid:${pid}:users_endorsed`);
+	};
 };

--- a/src/posts/index.js
+++ b/src/posts/index.js
@@ -23,6 +23,7 @@ require('./recent')(Posts);
 require('./tools')(Posts);
 require('./votes')(Posts);
 require('./bookmarks')(Posts);
+require('./endorsements')(Posts);
 require('./queue')(Posts);
 require('./diffs')(Posts);
 require('./uploads')(Posts);


### PR DESCRIPTION
Resolves #14 

This PR added a file that stores information on the endorsements of a post. It does this through the redis database. There were also some other changes made that began the API for endorsing a post.

This stores information on the endorsements per post and per user in the redis database.
<img width="732" height="305" alt="image" src="https://github.com/user-attachments/assets/1c1e759a-9e20-4148-9325-9f7b48902b75" />

These are the changes to the post object to include the extra fields "endorsements" and "endorsed"
<img width="781" height="342" alt="image" src="https://github.com/user-attachments/assets/560f55a5-b5bb-4a0a-bb87-247181f822e6" />

Here is the testing suite to show no failing tests
<img width="783" height="170" alt="image" src="https://github.com/user-attachments/assets/a4bcfa3e-3ade-4fa5-abf8-057b3a4c4cae" />

TODO:
- Finish the API to allow for endorsements and unendorsements
- Add testing to the new API changes