### PR TITLE
Acee3/backend endorsements service

### DIFF
--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -103,12 +103,12 @@ define('forum/topic/postTools', [
 
 		handleSelectionTooltip();
 		
-		postContainer.on('click', '[component="post/unendorse"]', function () {
+		postContainer.on('click', '[component="post/endorse"]', function () {
 			return endorsePost($(this), getData($(this), 'data-pid'));
 		});
 
-		postContainer.on('click', '[component="post/endorse"]', function () {
-			return unEndorsePost($(this), getData($(this), 'data-pid'));
+		postContainer.on('click', '[component="post/unendorse"]', function () {
+			return endorsePost($(this), getData($(this), 'data-pid'));
 		});
 
 		postContainer.on('click', '[component="post/quote"]', function () {
@@ -395,36 +395,15 @@ define('forum/topic/postTools', [
 
 	function endorsePost(button, pid) {
 		const isEndorsed = button.attr('posts-endorsed') === 'true';
-		
-		if (isEndorsed) {
-			// alreayd endorsed, return
-			return false;
-		}
-		
-		// call API with PUT method, TODO : create API route for endorse
-		api.put(`/posts/${encodeURIComponent(pid)}/endorse`, undefined, function (err) {
+		console.log(isEndorsed + ' isEndorsed');
+		const method = button.attr('posts-endorsed') === 'false' ? 'put' : 'del';
+		console.log(method);
+		api[method](`/posts/${encodeURIComponent(pid)}/endorse`, undefined, function (err) {
 			if (err) {
 				return alerts.error(err);
 			}
-			// success : hooks.fire()?
-		});
-		return false;
-	}
-
-	function unEndorsePost(button, pid) {
-		const isEndorsed = button.attr('posts-endorsed') === 'true';
-		
-		if (!isEndorsed) {
-			// alreayd un-endorsed, return
-			return false;
-		}
-		
-		// call API with DEL method, TODO : create API route for unendorse
-		api.del(`/posts/${encodeURIComponent(pid)}/unendorse`, undefined, function (err) {
-			if (err) {
-				return alerts.error(err);
-			}
-			// success : hooks.fire()?
+			const type = method === 'put' ? 'endorse' : 'unendorse';
+			hooks.fire(`action:post.${type}`, { pid: pid });
 		});
 		return false;
 	}

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -394,10 +394,8 @@ define('forum/topic/postTools', [
 	}
 
 	function endorsePost(button, pid) {
-		const isEndorsed = button.attr('posts-endorsed') === 'true';
-		console.log(isEndorsed + ' isEndorsed');
 		const method = button.attr('posts-endorsed') === 'false' ? 'put' : 'del';
-		console.log(method);
+		
 		api[method](`/posts/${encodeURIComponent(pid)}/endorse`, undefined, function (err) {
 			if (err) {
 				return alerts.error(err);

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -477,6 +477,14 @@ postsAPI.unbookmark = async function (caller, data) {
 	return await apiHelpers.postCommand(caller, 'unbookmark', 'bookmarked', '', data);
 };
 
+postsAPI.endorse = async function (caller, data) {
+	return await apiHelpers.postCommand(caller, 'endorse', 'endorsed', '', data);
+};
+
+postsAPI.unendorse = async function (caller, data) {
+	return await apiHelpers.postCommand(caller, 'unendorse', 'endorsed', '', data);
+};
+
 async function diffsPrivilegeCheck(pid, uid) {
 	const [deleted, privilegesData] = await Promise.all([
 		posts.getPostField(pid, 'deleted'),

--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -163,6 +163,18 @@ Posts.unbookmark = async (req, res) => {
 	helpers.formatApiResponse(200, res);
 };
 
+Posts.endorse = async (req, res) => {
+	const data = await mock(req);
+	await api.posts.endorse(req, data);
+	helpers.formatApiResponse(200, res);
+};
+
+Posts.unendorse = async (req, res) => {
+	const data = await mock(req);
+	await api.posts.unendorse(req, data);
+	helpers.formatApiResponse(200, res);
+};
+
 Posts.getDiffs = async (req, res) => {
 	helpers.formatApiResponse(200, res, await api.posts.getDiffs(req, { ...req.params }));
 };

--- a/src/routes/write/posts.js
+++ b/src/routes/write/posts.js
@@ -33,6 +33,8 @@ module.exports = function () {
 	setupApiRoute(router, 'get', '/:pid/announcers/tooltip', [middleware.assert.post], controllers.write.posts.getAnnouncersTooltip);
 	setupApiRoute(router, 'put', '/:pid/bookmark', middlewares, controllers.write.posts.bookmark);
 	setupApiRoute(router, 'delete', '/:pid/bookmark', middlewares, controllers.write.posts.unbookmark);
+	setupApiRoute(router, 'put', '/:pid/endorse', middlewares, controllers.write.posts.endorse);
+	setupApiRoute(router, 'delete', '/:pid/endorse', middlewares, controllers.write.posts.unendorse);
 
 	setupApiRoute(router, 'get', '/:pid/diffs', [middleware.assert.post], controllers.write.posts.getDiffs);
 	setupApiRoute(router, 'get', '/:pid/diffs/:since', [middleware.assert.post], controllers.write.posts.loadDiff);

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -120,12 +120,14 @@ module.exports = function (Topics) {
 		}
 		const [
 			bookmarks,
+			endorsements,
 			voteData,
 			userData,
 			editors,
 			replies,
 		] = await Promise.all([
 			posts.hasBookmarked(pids, uid),
+			posts.hasEndorsed(pids, uid),
 			posts.getVoteStatusByPostIDs(pids, uid),
 			getPostUserData('uid', async uids => await posts.getUserInfoForPosts(uids, uid)),
 			getPostUserData('editor', async uids => await user.getUsersFields(uids, ['uid', 'username', 'userslug'])),
@@ -138,6 +140,7 @@ module.exports = function (Topics) {
 				postObj.user = postObj.uid ? userData[postObj.uid] : { ...userData[postObj.uid] };
 				postObj.editor = postObj.editor ? editors[postObj.editor] : null;
 				postObj.bookmarked = bookmarks[i];
+				postObj.endorsed = endorsements[i];
 				postObj.upvoted = voteData.upvotes[i];
 				postObj.downvoted = voteData.downvotes[i];
 				postObj.votes = postObj.votes || 0;

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
@@ -111,8 +111,8 @@
 				<div component="post/actions" class="d-flex flex-grow-1 align-items-center justify-content-end gap-1 post-tools">
 					<!-- IMPORT partials/topic/reactions.tpl -->
 					<!-- TODO : replace 'post-endorsed' attr variable after post field created -->
-					<a component="post/unendorse" href="#" class="btn btn-ghost btn-sm {{{ if !privileges.isAdminOrMod }}}hidden{{{ end }}}" title="Un-endorse this post" posts-endorsed="false"><i class="fa fa-fw fa-star-o text-primary"></i></a>
-					<a component="post/endorse" href="#" class="btn btn-ghost btn-sm {{{ if !privileges.isAdminOrMod }}}hidden{{{ end }}}" title="Endorse this post" posts-endorsed="true"><i class="fa fa-fw fa-star text-primary"></i></a>
+					<a component="post/unendorse" href="#" class="btn btn-ghost btn-sm {{{ if !privileges.isAdminOrMod }}}hidden{{{ end }}}" title="Un-endorse this post" posts-endorsed="{posts.endorsed}"><i class="fa fa-fw fa-star-o text-primary"></i></a>
+					<a component="post/endorse" href="#" class="btn btn-ghost btn-sm {{{ if !privileges.isAdminOrMod }}}hidden{{{ end }}}" title="Endorse this post" posts-endorsed="{posts.endorsed}"><i class="fa fa-fw fa-star text-primary"></i></a>
 					<a component="post/reply" href="#" class="btn btn-ghost btn-sm {{{ if !privileges.topics:reply }}}hidden{{{ end }}}" title="[[topic:reply]]"><i class="fa fa-fw fa-reply text-primary"></i></a>
 					<a component="post/quote" href="#" class="btn btn-ghost btn-sm {{{ if !privileges.topics:reply }}}hidden{{{ end }}}" title="[[topic:quote]]"><i class="fa fa-fw fa-quote-right text-primary"></i></a>
 


### PR DESCRIPTION
## 1. Feature / Enhancement

Resolves #15 

1. Added to the frontend topic posts object the endorsements data
2. Refactored frontend code to use same endorse function that now stores the endorsed state in the HTML 
3. Added routing to the backend service
4. Finished backend service

## 2. To-Do

- [ ] update endorsements to only admins/professors
- [ ] combine endorsement buttons into one togglable button in the UI
- [ ] automatic updates to the endorsement state through websockets (stretch)


