### PR TITLE
Refactor (public/src/client/topic.js): reduce nesting in addCodeBlockHandler()

### DIFF
--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -218,6 +218,32 @@ define('forum/topic', [
 		});
 	}
 
+	function addCopyCodeButton() {
+		function scrollbarVisible(element) {
+			return element.scrollHeight > element.clientHeight;
+		}
+		function offsetCodeBtn(codeEl) {
+			if (!codeEl.length) { return; }
+			if (!codeEl[0].scrollHeight) {
+				return setTimeout(offsetCodeBtn, 100, codeEl);
+			}
+			if (scrollbarVisible(codeEl.get(0))) {
+				codeEl.parent().parent().find('[component="copy/code/btn"]').css({ margin: '0.5rem 1.5rem 0 0' });
+			}
+		}
+		let codeBlocks = $('[component="topic"] [component="post/content"] code:not([data-button-added])');
+		codeBlocks = codeBlocks.filter((i, el) => $(el).text().includes('\n'));
+		const container = $('<div class="hover-parent position-relative"></div>');
+		const buttonDiv = $('<button component="copy/code/btn" class="hover-visible position-absolute top-0 btn btn-sm btn-outline-secondary" style="right: 0px; margin: 0.5rem 0.5rem 0 0;"><i class="fa fa-fw fa-copy"></i></button>');
+		const preEls = codeBlocks.parent();
+		preEls.wrap(container).parent().append(buttonDiv);
+		preEls.parent().find('[component="copy/code/btn"]').translateAttr('title', '[[topic:copy-code]]');
+		preEls.each((index, el) => {
+			offsetCodeBtn($(el).find('code'));
+		});
+		codeBlocks.attr('data-button-added', 1);
+	}
+
 	function addCodeBlockHandler() {
 		new clipboard('[component="copy/code/btn"]', {
 			text: function (trigger) {
@@ -232,32 +258,7 @@ define('forum/topic', [
 				return codeEl.text();
 			},
 		});
-
-		function addCopyCodeButton() {
-			function scrollbarVisible(element) {
-				return element.scrollHeight > element.clientHeight;
-			}
-			function offsetCodeBtn(codeEl) {
-				if (!codeEl.length) { return; }
-				if (!codeEl[0].scrollHeight) {
-					return setTimeout(offsetCodeBtn, 100, codeEl);
-				}
-				if (scrollbarVisible(codeEl.get(0))) {
-					codeEl.parent().parent().find('[component="copy/code/btn"]').css({ margin: '0.5rem 1.5rem 0 0' });
-				}
-			}
-			let codeBlocks = $('[component="topic"] [component="post/content"] code:not([data-button-added])');
-			codeBlocks = codeBlocks.filter((i, el) => $(el).text().includes('\n'));
-			const container = $('<div class="hover-parent position-relative"></div>');
-			const buttonDiv = $('<button component="copy/code/btn" class="hover-visible position-absolute top-0 btn btn-sm btn-outline-secondary" style="right: 0px; margin: 0.5rem 0.5rem 0 0;"><i class="fa fa-fw fa-copy"></i></button>');
-			const preEls = codeBlocks.parent();
-			preEls.wrap(container).parent().append(buttonDiv);
-			preEls.parent().find('[component="copy/code/btn"]').translateAttr('title', '[[topic:copy-code]]');
-			preEls.each((index, el) => {
-				offsetCodeBtn($(el).find('code'));
-			});
-			codeBlocks.attr('data-button-added', 1);
-		}
+		
 		hooks.registerPage('action:posts.loaded', addCopyCodeButton);
 		hooks.registerPage('action:topic.loaded', addCopyCodeButton);
 		hooks.registerPage('action:posts.edited', addCopyCodeButton);


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

**Use this pull request template to briefly answer the questions below in one to two sentences each.**
Feel free to delete this text at the top after filling out the template.

> You are **not permitted** to use generative AI services (e.g., ChatGPT) to compose the answers.
> Any such use will be treated as a violation of academic integrity.

## 1. Issue

**Please provide a link to the associated GitHub issue: **

**Link to the associated GitHub issue: https://github.com/CMU-313/NodeBB/issues/99**

**Full path to the refactored file: public/src/client/topic.js**

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*
This file defines the logic necessary for the frontend for Topics. It initializes the Topics using a bunch of handlers that implement some technology like the code block or the replies. Some evidence for this is that the handlers are run when I open a post in the UI.

**What is the scope of your refactoring within that file?**
*(Name specific functions/blocks/regions touched.)*
I changed the addCodeBlockHandler function that is used within the Topic.init function. I moved the inner function addCopyCodeButton found in the addCodeBlockHandler to outside.

**Which Qlty‑reported issue did you address?**
*(Name the rule/metric and include the BEFORE value; e.g., “Cognitive Complexity 18 in render()”.)*
Qlty reported this issue as "221  Function with high complexity (count = 11): addCodeBlockHandler"

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
The specific issue I chose impacted the codebase's adaptability by making it difficult for a programmer to understand what the function does by not abstracting away the implementation of the addCopyCodeButton.

**What changes did you make to resolve the issue?**
I moved the addCopyCodeButton away from the function to not be nested.

**How do your changes improve adaptability? Did you consider alternatives?**
The changes I made improved adaptability by making it more modular and readable as someone who is interested in the addCodeBlockHandler would now no longer need to see the addCopyCodeButton implementation if they are not interested. Additionally, if the function were to be used in another function, the codebase can adapt by simply calling the function now. I considered moving some of the other parts of the addCodeBlackHandler to within the now separate addCopyCodeButton function, but that would be unnecessary and make the responsibility of the addCopyCodeButton larger and less intuitive.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
I opened the app and logged in. Then, I went to the general discussions page to make a new topic. I added a code block and made the post. Upon opening the new post, the refactored code was triggered.

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(Run `./nodebb log`; include the relevant UI view. Temporary logs should be removed before final commit.)*
<img width="1470" height="818" alt="Screenshot 2025-09-03 at 12 31 59 AM" src="https://github.com/user-attachments/assets/25a6a23f-62a1-4e41-ac64-11d06f31811d" />


**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="909" height="250" alt="image" src="https://github.com/user-attachments/assets/ded42708-fe0d-4279-bad4-ea629f77d5a1" />
