### PR TITLE
Unit tests for Endorsement Backend

### DIFF
--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -218,6 +218,32 @@ define('forum/topic', [
 		});
 	}
 
+	function addCopyCodeButton() {
+		function scrollbarVisible(element) {
+			return element.scrollHeight > element.clientHeight;
+		}
+		function offsetCodeBtn(codeEl) {
+			if (!codeEl.length) { return; }
+			if (!codeEl[0].scrollHeight) {
+				return setTimeout(offsetCodeBtn, 100, codeEl);
+			}
+			if (scrollbarVisible(codeEl.get(0))) {
+				codeEl.parent().parent().find('[component="copy/code/btn"]').css({ margin: '0.5rem 1.5rem 0 0' });
+			}
+		}
+		let codeBlocks = $('[component="topic"] [component="post/content"] code:not([data-button-added])');
+		codeBlocks = codeBlocks.filter((i, el) => $(el).text().includes('\n'));
+		const container = $('<div class="hover-parent position-relative"></div>');
+		const buttonDiv = $('<button component="copy/code/btn" class="hover-visible position-absolute top-0 btn btn-sm btn-outline-secondary" style="right: 0px; margin: 0.5rem 0.5rem 0 0;"><i class="fa fa-fw fa-copy"></i></button>');
+		const preEls = codeBlocks.parent();
+		preEls.wrap(container).parent().append(buttonDiv);
+		preEls.parent().find('[component="copy/code/btn"]').translateAttr('title', '[[topic:copy-code]]');
+		preEls.each((index, el) => {
+			offsetCodeBtn($(el).find('code'));
+		});
+		codeBlocks.attr('data-button-added', 1);
+	}
+
 	function addCodeBlockHandler() {
 		new clipboard('[component="copy/code/btn"]', {
 			text: function (trigger) {
@@ -232,32 +258,7 @@ define('forum/topic', [
 				return codeEl.text();
 			},
 		});
-
-		function addCopyCodeButton() {
-			function scrollbarVisible(element) {
-				return element.scrollHeight > element.clientHeight;
-			}
-			function offsetCodeBtn(codeEl) {
-				if (!codeEl.length) { return; }
-				if (!codeEl[0].scrollHeight) {
-					return setTimeout(offsetCodeBtn, 100, codeEl);
-				}
-				if (scrollbarVisible(codeEl.get(0))) {
-					codeEl.parent().parent().find('[component="copy/code/btn"]').css({ margin: '0.5rem 1.5rem 0 0' });
-				}
-			}
-			let codeBlocks = $('[component="topic"] [component="post/content"] code:not([data-button-added])');
-			codeBlocks = codeBlocks.filter((i, el) => $(el).text().includes('\n'));
-			const container = $('<div class="hover-parent position-relative"></div>');
-			const buttonDiv = $('<button component="copy/code/btn" class="hover-visible position-absolute top-0 btn btn-sm btn-outline-secondary" style="right: 0px; margin: 0.5rem 0.5rem 0 0;"><i class="fa fa-fw fa-copy"></i></button>');
-			const preEls = codeBlocks.parent();
-			preEls.wrap(container).parent().append(buttonDiv);
-			preEls.parent().find('[component="copy/code/btn"]').translateAttr('title', '[[topic:copy-code]]');
-			preEls.each((index, el) => {
-				offsetCodeBtn($(el).find('code'));
-			});
-			codeBlocks.attr('data-button-added', 1);
-		}
+		
 		hooks.registerPage('action:posts.loaded', addCopyCodeButton);
 		hooks.registerPage('action:topic.loaded', addCopyCodeButton);
 		hooks.registerPage('action:posts.edited', addCopyCodeButton);

--- a/test/posts.js
+++ b/test/posts.js
@@ -281,6 +281,22 @@ describe('Post\'s', () => {
 		});
 	});
 
+	describe('endorsing', () => {
+		it('should endorse a post', async () => {
+			const data = await apiPosts.endorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
+			assert.equal(data.isEndorsed, true);
+			const hasEndorsed = await posts.hasEndorsed(postData.pid, voterUid);
+			assert.equal(hasEndorsed, true);
+		});
+
+		it('should unendorse a post', async () => {
+			const data = await apiPosts.unendorse({ uid: voterUid }, { pid: postData.pid, room_id: `topic_${postData.tid}` });
+			assert.equal(data.isEndorsed, false);
+			const hasEndorsed = await posts.hasEndorsed([postData.pid], voterUid);
+			assert.equal(hasEndorsed[0], false);
+		});
+	});
+
 	describe('post tools', () => {
 		it('should error if data is invalid', (done) => {
 			socketPosts.loadPostTools({ uid: globalModUid }, null, (err) => {


### PR DESCRIPTION
Added a unit test for both endorsing and unendorsing on the backend. 

Context
Link to the associated GitHub issue: #11 
This added some tests (more to be added in the future) for the endorsement backend api.

Description
This PR adds two basic unit tests for endorsing and unendorsing for the backend api. It checks that the state is saved after endorsing/unendorsing.

Changes in the codebase
test/posts.js includes a unit test with two requirements.