### PR TITLE
(WIP) Fix : Address CI test failure for endorsement visibility and live update (PR #35)

### DIFF
--- a/src/api/helpers.js
+++ b/src/api/helpers.js
@@ -138,6 +138,12 @@ async function executeCommand(caller, command, eventName, notification, data) {
 	if (result && command === 'upvote') {
 		socketHelpers.upvote(result, notification);
 		await api.activitypub.like.note(caller, { pid: data.pid });
+	} else if (result && command === 'endorse') {
+		socketHelpers.sendNotificationToPostOwner(data.pid, caller.uid, command, notification);
+		// Note: ActivityPub endorse integration would go here when implemented
+	} else if (result && command === 'unendorse') {
+		socketHelpers.sendNotificationToPostOwner(data.pid, caller.uid, command, notification);
+		// Note: ActivityPub undo endorse integration would go here when implemented
 	} else if (result && notification) {
 		socketHelpers.sendNotificationToPostOwner(data.pid, caller.uid, command, notification);
 	} else if (result && command === 'unvote') {


### PR DESCRIPTION
This PR fixes lint and testing errors introduced by PR #35. This branch / PR is based off the merged PR that was causing the errors, meaning the changes for endorsement live updates are kept but only additional codes were added to pass testing.

## 1. Issue
Test run on merge PR for endorsement visibility and live updates failed by exceeding timeout limit at `executeCommand()` in `/src/routes/helpers.js`.

<img width="1117" height="338" alt="Screenshot 2025-09-26 at 1 33 28 PM" src="https://github.com/user-attachments/assets/ae2b0961-d187-49ca-ad12-332166726d14" />


## 2. Cause
The endorsement feature was added to NodeBB but was missing from the ActivityPub command execution flow in `src/api/helpers.js` (which the routes call for endorsement) causing ActivityPub integration tests to fail with timeouts in CI environments.

In detail, after analysis on testing codebase, found that integrated tests tested on various post features (ex. upvote, endorsement) by calling them. However, no handler was found for endorsement feature in the mentioned file above, leading to incomplete async function calls. (thereby timeout)

## 3. Changes
Command handlers were added with similar pattern to existing commands to complete the async operation. 
<img width="753" height="143" alt="Screenshot 2025-09-26 at 1 43 02 PM" src="https://github.com/user-attachments/assets/31ca24f3-5a30-4126-bf0f-11a42a19c6a8" />

Note that this does not include changes for any implementation of endorsement in ActivityPub. Currently endorsements are only available locally on NodeBB only.

## 4. Results
Tests done on local branch passes without any errors and Github checks no longer raise an error.
<img width="617" height="102" alt="Screenshot 2025-09-26 at 1 47 38 PM" src="https://github.com/user-attachments/assets/bf67a6e9-0a26-4bb4-b729-b35643b825ef" />
