### PR TITLE
feat: Create UI for Search by Title feature 

### DIFF
--- a/public/language/en-GB/recent.json
+++ b/public/language/en-GB/recent.json
@@ -8,6 +8,7 @@
 	"no-recent-topics": "There are no recent topics.",
 	"no-popular-topics": "There are no popular topics.",
 	"load-new-posts": "Load new posts",
+	"search-topics": "Search topics by title",
 
 	"uncategorized.title": "All known topics",
 	"uncategorized.intro": "This page shows a chronological listing of every topic that this forum has received.<br />The views and opinions expressed in the topics below are not moderated and may not represent the views and opinions of this website."

--- a/src/views/partials/topic-search-bar.tpl
+++ b/src/views/partials/topic-search-bar.tpl
@@ -1,0 +1,16 @@
+<div class="btn-group bottom-sheet">
+	<div class="input-group input-group-sm">
+		<button class="btn btn-outline" type="button" component="topic/search">
+			<i class="fa fa-search text-primary"></i>
+		</button>
+		<input type="text" 
+			   class="form-control" 
+			   component="topic/input" 
+			   placeholder="[[recent:search-topics]]" 
+			   value="{{{ if searchQuery }}}{searchQuery}{{{ end }}}"
+			   autocomplete="off">
+		<button class="btn btn-outline" type="button" component="topic/search/clear">
+			<i class="fa fa-times"></i>
+		</button>
+	</div>
+</div>

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic-list-bar.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic-list-bar.tpl
@@ -14,6 +14,7 @@
 				<!-- IMPORT partials/topic-filters.tpl -->
 				<!-- IMPORT partials/category/filter-dropdown-left.tpl -->
 				<!-- IMPORT partials/tags/filter-dropdown-left.tpl -->
+				<!-- IMPORT partials/topic-search-bar.tpl -->
 				{{{ end }}}
 				{{{ if template.unread }}}
 				<div class="markread btn-group {{{ if !topics.length }}}hidden{{{ end }}}">


### PR DESCRIPTION
### Context
Link to the associated GitHub issue: https://github.com/CMU-313/nodebb-fall-2025-unknown/issues/12

The feature will allow users to search for posts based on their title. The user will be able to input some text into the search bar to query the database for posts with a similar title.

### Description
This PR handles creating the UI for the search functionality. 

### Changes in the codebase
I have created a new partial for the search bar UI. I then added this partial to the topic-list-bar.tpl file so that the search bar is rendered across the different pages within the tool bar for the various filter tools. 
<img width="1303" height="410" alt="Screenshot 2025-09-29 at 1 37 03 PM" src="https://github.com/user-attachments/assets/41892157-1dec-4ae9-b7ac-ad5d33538eef" />
