### PR TITLE
feat: added UI for the fuzzy search button

### DIFF
--- a/src/views/partials/topic-search-bar.tpl
+++ b/src/views/partials/topic-search-bar.tpl
@@ -12,5 +12,12 @@
 		<button class="btn btn-outline" type="button" component="topic/search/clear">
 			<i class="fa fa-times"></i>
 		</button>
+	<button 
+		class="btn btn-outline" 
+		type="button" 
+		component="topic/toggle" 
+		data-selected="{toggleSelected}">
+		Fuzzy Search
+	</button>
 	</div>
 </div>


### PR DESCRIPTION
### Context
Link to the associated GitHub issue: https://github.com/CMU-313/nodebb-fall-2025-unknown/issues/12

The feature will allow users to search for posts based on their title. The user will be able to input some text into the search bar to query the database for posts with a similar title.

### Description
This PR handles creating the UI button for the fuzzy search functionality. 

### Changes in the codebase
I then added a new button to the partial  topic-search-bar.tpl to handle toggling the fuzzy search functionality. 
<img width="1295" height="435" alt="Screenshot 2025-10-05 at 1 17 08 PM" src="https://github.com/user-attachments/assets/8bde4276-6b0b-4176-a48d-b91e0c997178" />
