### PR TITLE
Fix: Deployment Setup- Replace commented out return with process.exit

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -110,7 +110,7 @@ prestart.versionCheck();
 
 if (!configExists && process.argv[2] !== 'setup') {
 	require('./setup').webInstall();
-	// return;
+	process.exit(0);
 }
 
 if (configExists) {


### PR DESCRIPTION
Fix deployment setup:

Replace commented return statement in src/cli/index.js with process.exit(0) 

so that this function call can still exit to fix the deployment issue, 

while avoiding the babel compilation error (caused by return statement).